### PR TITLE
Add macOS build/support and packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /dist/
 *.pyc
 __pycache__/
+.DS_Store
+/deps/macos/*.app/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 __pycache__/
 .DS_Store
 /deps/macos/*.app/
+/deps/macos/*.app.tar.xz

--- a/3dm.spec
+++ b/3dm.spec
@@ -7,22 +7,26 @@ from PyInstaller.utils.hooks import collect_submodules
 deps_dir = {
     'Linux': 'deps/linux',
     'Windows': 'deps/windows',
+    'Darwin': 'deps/macos',
 }[platform.system()]
 
+datas = [
+    (f'./default_config', 'default_config'),
+    (f'./scad_library', 'scad_library'),
+    (f'README.md', '.'),
+    (f'template.gcode.3mf', '.'),
+]
+
+if platform.system() != 'Darwin':
+    datas.append((f'./{deps_dir}', deps_dir))
 
 a = Analysis(
     ['3dm.py'],
     pathex=[],
     binaries=[],
-    datas=[
-        (f'./{deps_dir}', deps_dir),
-        (f'./default_config', 'default_config'),
-        (f'./scad_library', 'scad_library'),
-        (f'README.md', '.'),
-        (f'template.gcode.3mf', '.'),
-    ],
+    datas=datas,
     hiddenimports=[
-        'prompt-toolkit', # For some reason pyinstaller doesn't pick this up in Windows
+        'prompt_toolkit', # For some reason pyinstaller doesn't pick this up in Windows
     ] + collect_submodules('vtkmodules'),
     hookspath=[],
     hooksconfig={},

--- a/3dm.spec
+++ b/3dm.spec
@@ -17,6 +17,8 @@ datas = [
     (f'template.gcode.3mf', '.'),
 ]
 
+# macOS helper apps are already complete app bundles; copy them after PyInstaller
+# so it does not rewrite or re-sign their internal executables and frameworks.
 if platform.system() != 'Darwin':
     datas.append((f'./{deps_dir}', deps_dir))
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,160 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Design advice
+Please ask for clarification when necessary when responding to requests.
+
+When extending existing code to a new use case, it's better to refactor the existing code cleanly rather than adding a patch around it. For example, if we have a function that produces metadata objects and JSON serializes them, and we now need one that produces similar metadata in YAML with a couple added fields, it's better to factor out the logic for the common metadata into a new function that returns a dict, then add JSON and YAML functions. It's not good to take the JSON function and write a wrapper that deserializes it, adds a couple fields, and then serializes it into YAML. This principle generalizes
+
+## Commands
+
+### Development Environment
+- **Dependencies**: Uses Pipenv for dependency management
+  - `pipenv install` - Install dependencies
+  - `pipenv shell` - Activate virtual environment
+  - Python 3.13 is required (see Pipfile)
+
+### Running the Application
+- **Main entry point**: `python 3dm.py` or `./3dm.py` (executable Python script)
+- **Common commands**:
+  - `python 3dm.py setup` - Initial configuration setup
+  - `python 3dm.py new` - Create new 3DMake project
+  - `python 3dm.py build` - Build OpenSCAD model to STL
+  - `python 3dm.py build slice` - Build and slice to GCODE
+  - `python 3dm.py build slice print` - Full pipeline to printing
+  - `python 3dm.py help` - Show all available actions
+
+### Testing
+- E2E tests live in `e2e_test.py`, run with `pytest e2e_test.py`
+- Test fixture files (STL, SCAD, sample projects) live in `test_fixtures/`
+
+## Coding Style
+
+### Comments
+- Avoid obvious comments that merely restate what the code does
+- Only add comments when they explain *why* something is done or provide non-obvious context
+- Examples of comments to avoid:
+  - `# Load existing cache if it exists` (obvious from the code)
+  - `# Check if we need to fetch` (obvious from the conditional)
+  - `# Update cache with new timestamp` (obvious from the assignment)
+- Prefer clear variable names and simple code structure over explanatory comments
+- Docstrings should be concise and focus on the function's purpose, not implementation details
+
+## Architecture Overview
+
+### Core Architecture
+3DMake follows a **command-action pipeline architecture** where:
+1. Commands are parsed from CLI arguments into "verbs" (actions)
+2. Actions can imply other actions (e.g., `print` implies `slice`)
+3. Actions run in sequence, passing a shared `Context` object
+4. Each action can be either `isolated` (runs alone) or `pipeline` (part of a workflow)
+
+### Key Components
+
+#### Main Entry Point (`3dm.py`)
+- Parses command-line arguments using argparse
+- Loads configuration from TOML files (global `defaults.toml` + project `3dmake.toml`)
+- Builds a `Context` object with options, file paths, and config directory
+- Executes actions in sequence from `ALL_ACTIONS_IN_ORDER`
+
+#### Action Framework (`actions/framework.py`)
+- **Context**: Shared state object containing config, file paths, and intermediate results
+- **Action**: Dataclass defining action metadata and implementation
+- **Decorators**:
+  - `@isolated_action`: Actions that run alone (setup, help, version)
+  - `@pipeline_action`: Actions that are part of build/print workflows
+  - `@internal_action`: Internal steps that don't show user output
+
+#### Core Types (`coretypes.py`)
+- **CommandOptions**: Configuration settings merged from defaults.toml, 3dmake.toml, and CLI args
+- **FileSet**: Tracks input files and outputs through the pipeline (scad → stl → oriented_stl → gcode)
+- **MeshMetrics**: 3D mesh analysis data (bounding box, dimensions)
+
+#### Actions (`actions/` directory)
+Actions are organized by functionality:
+- **Project management**: `new_action.py`, `edit_actions.py`
+- **Build pipeline**: `build_action.py`, `measure_action.py`, `orient_action.py`, `slice_action.py`
+- **Output**: `preview_action.py`, `image_action.py`, `print_action.py`
+- **Information**: `info_action.py`, `list_config_actions.py`, `help_action.py`
+- **Setup**: `setup_action.py`, `library_actions.py`
+
+#### Utilities (`utils/` directory)
+- `openscad.py`: OpenSCAD integration and STL generation
+- `renderer.py`: 3D model rendering for images and analysis
+- `print_config.py`: PrusaSlicer configuration management
+- `ftp.py`: Bambu Labs printer FTP integration
+- `prompts.py`: CLI interaction utilities
+
+### Configuration System
+- **Global config**: `~/.config/3dmake/defaults.toml` (via platformdirs)
+- **Project config**: `./3dmake.toml` in project directory
+- **Printer profiles**: `~/.config/3dmake/profiles/` (PrusaSlicer INI format)
+- **Overlays**: `~/.config/3dmake/overlays/` (setting modifications)
+- Settings cascade: defaults.toml → 3dmake.toml → CLI arguments
+
+### File Processing Pipeline
+1. **Input**: OpenSCAD `.scad` files or STL files
+2. **Build**: OpenSCAD → STL conversion
+3. **Measure**: Extract mesh metrics (dimensions, bounds)
+4. **Orient**: Auto-orient for optimal printing (optional)
+5. **Preview**: Generate 2D "silhouette" previews (optional)
+6. **Slice**: PrusaSlicer integration for GCODE generation
+7. **Print**: Send to OctoPrint or Bambu Labs printers
+
+### Dependencies and External Tools
+- **OpenSCAD**: 3D modeling (bundled in `deps/` for Windows)
+- **PrusaSlicer**: Slicing engine (bundled in `deps/` for Windows)
+- **VTK/vtkplotlib**: 3D mesh processing and rendering
+- **Tweaker3**: Auto-orientation algorithm
+- **Google Generative AI**: Model description via image analysis
+- **paho-mqtt**: Bambu Labs printer communication
+
+### Preview Planes
+
+Preview planes generate 2D cross-sectional slices through a model at an arbitrary plane, producing an SVG and a thin extruded STL suitable for tactile graphics printing.
+
+#### How they work
+
+1. **SCAD definition** — The user places marker modules from `scad_library/3dmake/preview.scad` in their OpenSCAD source:
+   ```scad
+   use <3dmake/preview.scad>
+   xy_preview_plane("level", 1);                           // XY plane named "level#1"
+   translate([0, 0, 10]) xy_preview_plane("level", 2);    // XY plane named "level#2"
+   xz_preview_plane("front");
+   rotate([0, 0, 45]) xz_preview_plane("diagonal");
+   ```
+   Each module renders a pentagonal pyramid whose base defines the plane. The pyramid only renders when `$THREEDMAKE_PREVIEW_PLANE` matches its name, otherwise it only logs its name via `echo`.
+
+2. **Build phase** (`build_action.py`) — During a normal build, OpenSCAD stderr is parsed for `_3dm_log_scalar` log lines. All available plane names are collected into `ctx.build_metadata.preview_plane_names`.
+
+3. **Plane location** (`preview_action.py: build_and_locate_preview_plane`) — When the user runs `3dm preview --view level#1`, OpenSCAD is invoked again with `-D '$THREEDMAKE_PREVIEW_PLANE="level#1"'` so only that pyramid renders. The resulting STL is parsed to find the 5 extreme vertices (coordinates ≥ 100,000). Four of these are the square base corners; the fifth is an orientation marker on the +X side of the base that sticks out to `SIZE+1000` (making it the outlier by Euclidean distance from origin). The 4 corners are used to fit the plane and determine normal direction from the apex position. The marker direction from the corner centroid gives the in-plane `right` vector. This yields a `Plane(origin, normal, right)`.
+
+4. **Projection** — OpenSCAD is called with `projection(cut=true)` after aligning the model so the target plane sits at z=0. The alignment uses a `multmatrix` built from `[plane_right, plane_up, n_hat]` as rows, where `plane_up = cross(n_hat, plane_right)`. This fully constrains the in-plane orientation so that rotating the plane marker in SCAD produces a correspondingly rotated cross-section in the output. Output: `{stem}-{plane_name}.svg`.
+
+5. **SVG styling** — Path fill and stroke-width are updated in the SVG XML for tactile printing aesthetics.
+
+6. **STL extrusion** — The SVG is extruded 0.6mm via `linear_extrude` to produce `{stem}-{plane_name}.stl`.
+
+#### Key implementation details
+
+- Preview planes always use the un-oriented model (`ctx.files.model`, not `oriented_model`) because plane coordinates are defined in the original SCAD coordinate system.
+- `ensure_previewable_model` forces a fresh build when a preview plane is requested, since plane coordinates must match the current SCAD source.
+- The `PLANE_TOLERANCE` for coplanarity checks is 1 unit (may need tuning).
+- The orientation marker is identified as the outlier among the 5 far vertices using `argmax(|distance - median(distances)|)`, which works whether the marker is closer or farther than the corners depending on SIZE.
+- Silhouette previews (`topsil`, `3sil`, etc.) are a separate code path using orthographic projection; they don't go through the plane location machinery.
+
+#### Relevant files
+- `scad_library/3dmake/preview.scad` — User-facing SCAD modules
+- `scad_library/3dmake/_internal.scad` — `_3dm_log_scalar` logging helper
+- `actions/preview_action.py` — All plane location, projection, and styling logic
+- `actions/build_action.py` — Collects plane names from build stderr
+- `utils/openscad.py` — Log line parsing (`_3DM_PATTERN` regex)
+
+### Key Design Patterns
+- **Action Pipeline**: Sequential execution of configurable actions
+- **Context Passing**: Shared state object passed between all actions
+- **Decorator-based Registration**: Actions self-register using decorators
+- **File State Tracking**: FileSet tracks intermediate outputs through pipeline
+- **Configuration Layering**: Multiple TOML files with override precedence
+- **Cross-platform Bundling**: External tools bundled in `deps/` directory

--- a/Pipfile
+++ b/Pipfile
@@ -26,10 +26,12 @@ networkx = "*"
 pyinstaller = ">=6.19"
 pytest = "*"
 pexpect = '*'
-# These are transitive dependencies only used on Windows; we lock them here to avoid churn in Pipfile
+# These are transitive dependencies only used on platform-specific PyInstaller builds;
+# lock them here to avoid churn when building releases on each OS.
 pywin32-ctypes = {version = "*", markers = "sys_platform == 'win32'"}
 pefile = {version = "*", markers = "sys_platform == 'win32'"}
 colorama = {version = "*", markers = "sys_platform == 'win32'"}
+macholib = {version = "*", markers = "sys_platform == 'darwin'"}
 mypy = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e0a61d91fac7fe654c19800f6a7a184095bbcb10d3f934038629cc294fa13174"
+            "sha256": "7529383d144abbebaef983a2086e9bed8b7df7f3fb2842daab2db2d325811137"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1742,6 +1742,14 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==4.15.0"
+        },
+        "macholib": {
+            "hashes": [
+                "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea",
+                "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362"
+            ],
+            "markers": "sys_platform == 'darwin'",
+            "version": "==1.16.4"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Model design in 3DMake is based on [OpenSCAD](https://openscad.org/), a text-bas
 
 You can open your project's main model in a text editor with `3dm edit-model` - this will simply open the file `src/main.scad`. You can select a different model name with the `-m` option when running 3DMake; if you want to edit the "lid.scad" model, you'd run `3dm edit-model -m lid`.
 
-By default, 3DMake's edit commands use Notepad in Windows. To configure a different editor, you can set its path in the [3DMake configuration](#global-config) For example, to configure Notepad++ on Windows, you might add this line to your config:
+By default, 3DMake's edit commands use Notepad in Windows and the system text editor in macOS. To configure a different editor, you can set its path in the [3DMake configuration](#global-config) For example, to configure Notepad++ on Windows, you might add this line to your config:
 
 ```
 # The triple quotes below allow your program's path to contain backslashes
@@ -247,8 +247,8 @@ bambu_access_code | The access code for your Bambu printer          | none      
 bambu_serial_number | The serial number of your Bambu printer       | none                          | `"1234ABCDEF..."`
 auto_start_prints | When uploading to `3dm print`, start the print right away | `true`              | `false`
 strict_warnings | Fail `3dm build` when OpenSCAD sees a problem with your code | `false`[^1]           | `true`
-editor          | Command to open your preferred text editor        | "notepad" in Windows[^2]      | `"code"`
-edit_in_background | Exit 3DMake after starting an editor           | `true` when using Notepad, `false` otherwise     | `false`
+editor          | Command to open your preferred text editor        | "notepad" in Windows, "open -t" in macOS[^2] | `"code"`
+edit_in_background | Exit 3DMake after starting an editor           | `true` when using Notepad or `open -t`, `false` otherwise | `false`
 gemini_key      | Your Gemini API key (do not share this)           | What you set in 3dm setup     | `"47b64..."`
 llm_name        | The name of the gemini or OpenRouter model to use | Depends on 3dmake version     | `"gemini-2.5-pro"`
 openrouter_key  | Your OpenRouter API key (takes priority over Gemini) | none | `"sk-or-v1-1234..."`
@@ -269,7 +269,7 @@ Some of these settings can be further overridden on the command line (for exampl
 
 [^1]: `strict_warnings` is `false` in your global config, but it's `true` for 3dmake.toml files in newly created projects. This is because if you are trying to build OpenSCAD files you downloaded directly, many of them will produce warnings and be broken by a global setting of `true`. However, setting this to `true` for your new code is a good idea.
 
-[^2]: In macOS and Linux, 3DMake tries to use your existing `VISUAL` and `EDITOR` environment variables if you don't set an editor. If it finds none of those, it uses GNU Nano.
+[^2]: In macOS, 3DMake setup uses `open -t` so files open in your system text editor. If you don't set an editor in macOS or Linux, 3DMake tries your existing `VISUAL` and `EDITOR` environment variables. If it finds none of those, it uses GNU Nano.
 
 [^3]: If your text editor opens a new window, you generally want this to be true so you can keep the editor open and still use 3DMake in your terminal window. However, if your editor runs in the terminal (like Vim, for example), it will be broken by this setting.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Thanks for trying 3DMake!
 Download the latest version of 3DMake for your operating system by following these links:
 - [Windows](https://github.com/tdeck/3dmake/releases/latest/download/3dmake_windows.zip)
 - [Linux (x86-64)](https://github.com/tdeck/3dmake/releases/latest/download/3dmake_linux.tar.gz)
+- [macOS](https://github.com/tdeck/3dmake/releases/latest/download/3dmake_macos.tar.gz)
 
 3DMake is a command line program, which means you need to run it from the terminal (or command prompt). If you've never used the terminal before, read the [terminal quick start guide](docs/terminal_quick_start.md).
 
@@ -268,7 +269,7 @@ Some of these settings can be further overridden on the command line (for exampl
 
 [^1]: `strict_warnings` is `false` in your global config, but it's `true` for 3dmake.toml files in newly created projects. This is because if you are trying to build OpenSCAD files you downloaded directly, many of them will produce warnings and be broken by a global setting of `true`. However, setting this to `true` for your new code is a good idea.
 
-[^2]: In Linux, 3DMake tries to use your existing `VISUAL` and `EDITOR` environment variables if you don't set an editor. If it finds none of those, it uses GNU Nano.
+[^2]: In macOS and Linux, 3DMake tries to use your existing `VISUAL` and `EDITOR` environment variables if you don't set an editor. If it finds none of those, it uses GNU Nano.
 
 [^3]: If your text editor opens a new window, you generally want this to be true so you can keep the editor open and still use 3DMake in your terminal window. However, if your editor runs in the terminal (like Vim, for example), it will be broken by this setting.
 

--- a/actions/setup_action.py
+++ b/actions/setup_action.py
@@ -22,6 +22,7 @@ from utils.output_streams import OutputStream
 from utils.test_flags import in_test_mode, test_flag_set
 
 DEFAULT_WINDOWS_EDITOR = 'notepad'
+DEFAULT_MACOS_EDITOR = 'open -t'
 OLLAMA_LOCALHOST = 'http://localhost:11434'
 BAMBU_CONNECT_DOWNLOAD_PAGE = "https://wiki.bambulab.com/en/software/bambu-connect"
 
@@ -50,10 +51,11 @@ def get_default_settings() -> Dict[str, Any]:
         auto_start_prints=True,
     )
 
-    # For the most common platform, we pre-populate the defaults so that it makes
-    # the file easier to edit
     if platform.system() == 'Windows':
         settings['editor'] = DEFAULT_WINDOWS_EDITOR
+        settings['edit_in_background'] = True
+    elif platform.system() == 'Darwin':
+        settings['editor'] = DEFAULT_MACOS_EDITOR
         settings['edit_in_background'] = True
 
     return settings
@@ -349,4 +351,3 @@ def add_self_to_path(bin_path: Path):
             print(f"this to your shell config file (e.g. {shell_config_file}):")
             print(f'export PATH="{bin_path.parent}:$PATH"')
             print(f"After doing this, you must reload your shell.")
-

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -21,7 +21,9 @@ Functions used by more than one action should be placed in a file in the (utils 
 ## Release builds
 In order to avoid making the user install Python and a bunch of dependences, we use [PyInstaller](https://pyinstaller.org/en/stable/) to create a directory with an executable entry point. PyInstaller can also bundle everything into an EXE, but we don't do that because it works by extracting the EXE every single time, and we have very large bundled binaries that would be inefficient to extract.
 
-Release builds must be created on the operating system they're targeting. To make a release build, you must first install pipenv and pyenv. Then cd into the 3dmake repo's root directory and run `pipenv install`. Finally, you can run one of the build scripts `scripts/linux_build.sh` or `scripts/windows_build.ps1` from the repo's root dir.
+Release builds must be created on the operating system they're targeting. To make a release build, you must first install pipenv and pyenv. Then cd into the 3dmake repo's root directory and run `pipenv install`. Finally, you can run one of the build scripts `scripts/linux_build.sh`, `scripts/macos_build.sh`, or `scripts/windows_build.ps1` from the repo's root dir.
+
+Bundled OpenSCAD and PrusaSlicer dependencies live under `deps/<platform>`. Run `scripts/get_deps.sh macos` on macOS before building the macOS release; the macOS script copies `OpenSCAD.app` from `/Applications` by default, extracts `PrusaSlicer.app` from the current stable DMG into `deps/macos`, and writes compressed `*.app.tar.xz` archives. The app bundles themselves are ignored by Git; `scripts/macos_build.sh` extracts the compressed archives if the bundles are missing.
 
 ### Steps to make a new release:
 For now Troy will make all the releases, following this process:

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -23,7 +23,7 @@ In order to avoid making the user install Python and a bunch of dependences, we 
 
 Release builds must be created on the operating system they're targeting. To make a release build, you must first install pipenv and pyenv. Then cd into the 3dmake repo's root directory and run `pipenv install`. Finally, you can run one of the build scripts `scripts/linux_build.sh`, `scripts/macos_build.sh`, or `scripts/windows_build.ps1` from the repo's root dir.
 
-Bundled OpenSCAD and PrusaSlicer dependencies live under `deps/<platform>`. Run `scripts/get_deps.sh macos` on macOS before building the macOS release; the macOS script copies `OpenSCAD.app` from `/Applications` by default, extracts `PrusaSlicer.app` from the current stable DMG into `deps/macos`, and writes compressed `*.app.tar.xz` archives. The app bundles themselves are ignored by Git; `scripts/macos_build.sh` extracts the compressed archives if the bundles are missing.
+Bundled OpenSCAD and PrusaSlicer dependencies live under `deps/<platform>`. Run `scripts/get_deps.sh macos` on macOS before building the macOS release; the macOS script copies `OpenSCAD.app` from `/Applications` by default and extracts `PrusaSlicer.app` from the current stable DMG into `deps/macos`. The macOS app bundles are ignored by Git, so each macOS build machine should populate them locally before building.
 
 ### Steps to make a new release:
 For now Troy will make all the releases, following this process:

--- a/e2e_test.py
+++ b/e2e_test.py
@@ -394,6 +394,10 @@ def assert_stl_vertices_close(stl_path1: Path, stl_path2: Path, delta: float = 1
 class MockOctoPrintHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         if self.path == '/api/files/local':
+            content_length = int(self.headers.get('Content-Length', 0))
+            if content_length:
+                self.rfile.read(content_length)
+
             api_key = self.headers.get('X-Api-Key')
             if api_key == 'test_api_key':
                 self.send_response(201)

--- a/scripts/get_deps.sh
+++ b/scripts/get_deps.sh
@@ -1,43 +1,163 @@
 #! /bin/bash
-set -e
+set -euo pipefail
 
-DEPDIR="$(readlink -f $(dirname "$0")/../deps)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPDIR="$(cd "$SCRIPT_DIR/../deps" && pwd)"
 
-mkdir -p "$DEPDIR/windows"
-mkdir -p "$DEPDIR/linux"
+OPENSCAD_VERSION="2021.01"
+PRUSASLICER_LEGACY_VERSION="2.8.1"
+PRUSASLICER_MACOS_VERSION="2.9.4"
 
-#
-# Linux
-#
-#curl 'https://files.openscad.org/OpenSCAD-2021.01-x86_64.AppImage' > "$DEPDIR/linux/OpenSCAD.AppImage"
-#curl -L 'https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.8.1/PrusaSlicer-2.8.1+linux-x64-older-distros-GTK3-202409181354.AppImage' > "$DEPDIR/linux/PrusaSlicer.AppImage"
-#
-#chmod +x "$DEPDIR/linux/OpenSCAD.AppImage"
-#chmod +x "$DEPDIR/linux/PrusaSlicer.AppImage"
- 
-#
-# Windows
-# 
-TMPDIR="$(mktemp -d)"
-echo "tmp dir $TMPDIR"
-pushd "$TMPDIR"
-curl 'https://files.openscad.org/OpenSCAD-2021.01-x86-64.zip' > scad.zip
-curl -L 'https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.8.1/PrusaSlicer-2.8.1+win64-202409181359.zip' > slicer.zip
+OPENSCAD_LINUX_URL="https://files.openscad.org/OpenSCAD-${OPENSCAD_VERSION}-x86_64.AppImage"
+OPENSCAD_WINDOWS_URL="https://files.openscad.org/OpenSCAD-${OPENSCAD_VERSION}-x86-64.zip"
+OPENSCAD_MACOS_URL="https://files.openscad.org/OpenSCAD-${OPENSCAD_VERSION}.dmg"
 
-mkdir scad
-(
-    cd scad
-    unzip ../scad.zip
-    mv "$(ls -1 | head -n 1)" "$DEPDIR/windows/openscad"
-)
+PRUSASLICER_LINUX_URL="https://github.com/prusa3d/PrusaSlicer/releases/download/version_${PRUSASLICER_LEGACY_VERSION}/PrusaSlicer-${PRUSASLICER_LEGACY_VERSION}%2Blinux-x64-older-distros-GTK3-202409181354.AppImage"
+PRUSASLICER_WINDOWS_URL="https://github.com/prusa3d/PrusaSlicer/releases/download/version_${PRUSASLICER_LEGACY_VERSION}/PrusaSlicer-${PRUSASLICER_LEGACY_VERSION}%2Bwin64-202409181359.zip"
+PRUSASLICER_MACOS_URL="https://github.com/prusa3d/PrusaSlicer/releases/download/version_${PRUSASLICER_MACOS_VERSION}/PrusaSlicer-${PRUSASLICER_MACOS_VERSION}.dmg"
+OPENSCAD_MACOS_APP="${OPENSCAD_MACOS_APP:-/Applications/OpenSCAD.app}"
 
-mkdir slicer
-(
-    cd slicer
-    unzip ../slicer.zip
+usage() {
+    echo "Usage: scripts/get_deps.sh [linux|windows|macos|all]"
+    echo "Without an argument, downloads Windows dependencies to preserve the old default."
+}
 
-    mv "$(ls -1 | head -n 1)" "$DEPDIR/windows/prusaslicer"
-)
+new_tmpdir() {
+    mktemp -d 2>/dev/null || mktemp -d -t 3dmake_deps
+}
 
-popd
-rm -rf "$TMPDIR"
+download_linux() {
+    mkdir -p "$DEPDIR/linux"
+    curl -L "$OPENSCAD_LINUX_URL" -o "$DEPDIR/linux/OpenSCAD.AppImage"
+    curl -L "$PRUSASLICER_LINUX_URL" -o "$DEPDIR/linux/PrusaSlicer.AppImage"
+    chmod +x "$DEPDIR/linux/OpenSCAD.AppImage"
+    chmod +x "$DEPDIR/linux/PrusaSlicer.AppImage"
+}
+
+download_windows() {
+    mkdir -p "$DEPDIR/windows"
+
+    local tmpdir
+    tmpdir="$(new_tmpdir)"
+    echo "tmp dir $tmpdir"
+    pushd "$tmpdir" >/dev/null
+
+    curl -L "$OPENSCAD_WINDOWS_URL" -o scad.zip
+    curl -L "$PRUSASLICER_WINDOWS_URL" -o slicer.zip
+
+    mkdir scad
+    (
+        cd scad
+        unzip -q ../scad.zip
+        rm -rf "$DEPDIR/windows/openscad"
+        mv "$(ls -1 | head -n 1)" "$DEPDIR/windows/openscad"
+    )
+
+    mkdir slicer
+    (
+        cd slicer
+        unzip -q ../slicer.zip
+        rm -rf "$DEPDIR/windows/prusaslicer"
+        mv "$(ls -1 | head -n 1)" "$DEPDIR/windows/prusaslicer"
+    )
+
+    popd >/dev/null
+    rm -rf "$tmpdir"
+}
+
+copy_app_from_dmg() {
+    local dmg_path="$1"
+    local app_name="$2"
+    local dest_path="$3"
+    local mount_path="$4"
+
+    mkdir -p "$mount_path"
+    hdiutil attach "$dmg_path" -mountpoint "$mount_path" -nobrowse -quiet
+    rm -rf "$dest_path"
+    local mounted_app
+    mounted_app="$(find "$mount_path" -maxdepth 3 -name "$app_name" -type d -print -quit)"
+    if [[ -z "$mounted_app" ]]; then
+        echo "Could not find $app_name in $dmg_path" >&2
+        hdiutil detach "$mount_path" -quiet
+        return 1
+    fi
+    if ! cp -R "$mounted_app" "$dest_path"; then
+        hdiutil detach "$mount_path" -quiet
+        return 1
+    fi
+    hdiutil detach "$mount_path" -quiet
+
+    if command -v xattr >/dev/null; then
+        xattr -dr com.apple.quarantine "$dest_path" 2>/dev/null || true
+    fi
+}
+
+archive_macos_app() {
+    local app_name="$1"
+    local app_path="$DEPDIR/macos/$app_name"
+    local archive_path="$DEPDIR/macos/$app_name.tar.xz"
+
+    if [[ ! -d "$app_path" ]]; then
+        echo "Cannot archive missing app bundle: $app_path" >&2
+        exit 1
+    fi
+
+    echo "Creating $archive_path"
+    rm -f "$archive_path"
+    COPYFILE_DISABLE=1 tar -cJf "$archive_path" -C "$DEPDIR/macos" "$app_name"
+}
+
+download_macos() {
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+        echo "macOS dependencies must be extracted on macOS because they are distributed as DMG files." >&2
+        exit 1
+    fi
+
+    mkdir -p "$DEPDIR/macos"
+
+    local tmpdir
+    tmpdir="$(new_tmpdir)"
+    echo "tmp dir $tmpdir"
+
+    if [[ -d "$OPENSCAD_MACOS_APP" ]]; then
+        rm -rf "$DEPDIR/macos/OpenSCAD.app"
+        cp -R "$OPENSCAD_MACOS_APP" "$DEPDIR/macos/OpenSCAD.app"
+    else
+        curl -L "$OPENSCAD_MACOS_URL" -o "$tmpdir/openscad.dmg"
+        copy_app_from_dmg "$tmpdir/openscad.dmg" "OpenSCAD.app" "$DEPDIR/macos/OpenSCAD.app" "$tmpdir/openscad_mount"
+    fi
+
+    curl -L "$PRUSASLICER_MACOS_URL" -o "$tmpdir/prusaslicer.dmg"
+
+    copy_app_from_dmg "$tmpdir/prusaslicer.dmg" "PrusaSlicer.app" "$DEPDIR/macos/PrusaSlicer.app" "$tmpdir/prusaslicer_mount"
+
+    archive_macos_app "OpenSCAD.app"
+    archive_macos_app "PrusaSlicer.app"
+
+    rm -rf "$tmpdir"
+}
+
+target="${1:-windows}"
+case "$target" in
+    linux)
+        download_linux
+        ;;
+    windows)
+        download_windows
+        ;;
+    macos|darwin)
+        download_macos
+        ;;
+    all)
+        download_linux
+        download_windows
+        download_macos
+        ;;
+    -h|--help|help)
+        usage
+        ;;
+    *)
+        usage >&2
+        exit 1
+        ;;
+esac

--- a/scripts/get_deps.sh
+++ b/scripts/get_deps.sh
@@ -5,15 +5,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEPDIR="$(cd "$SCRIPT_DIR/../deps" && pwd)"
 
 OPENSCAD_VERSION="2021.01"
-PRUSASLICER_LEGACY_VERSION="2.8.1"
 PRUSASLICER_MACOS_VERSION="2.9.4"
 
 OPENSCAD_LINUX_URL="https://files.openscad.org/OpenSCAD-${OPENSCAD_VERSION}-x86_64.AppImage"
 OPENSCAD_WINDOWS_URL="https://files.openscad.org/OpenSCAD-${OPENSCAD_VERSION}-x86-64.zip"
 OPENSCAD_MACOS_URL="https://files.openscad.org/OpenSCAD-${OPENSCAD_VERSION}.dmg"
 
-PRUSASLICER_LINUX_URL="https://github.com/prusa3d/PrusaSlicer/releases/download/version_${PRUSASLICER_LEGACY_VERSION}/PrusaSlicer-${PRUSASLICER_LEGACY_VERSION}%2Blinux-x64-older-distros-GTK3-202409181354.AppImage"
-PRUSASLICER_WINDOWS_URL="https://github.com/prusa3d/PrusaSlicer/releases/download/version_${PRUSASLICER_LEGACY_VERSION}/PrusaSlicer-${PRUSASLICER_LEGACY_VERSION}%2Bwin64-202409181359.zip"
+PRUSASLICER_LINUX_URL="https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.8.1/PrusaSlicer-2.8.1%2Blinux-x64-older-distros-GTK3-202409181354.AppImage"
+PRUSASLICER_WINDOWS_URL="https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.8.1/PrusaSlicer-2.8.1%2Bwin64-202409181359.zip"
 PRUSASLICER_MACOS_URL="https://github.com/prusa3d/PrusaSlicer/releases/download/version_${PRUSASLICER_MACOS_VERSION}/PrusaSlicer-${PRUSASLICER_MACOS_VERSION}.dmg"
 OPENSCAD_MACOS_APP="${OPENSCAD_MACOS_APP:-/Applications/OpenSCAD.app}"
 
@@ -23,6 +22,7 @@ usage() {
 }
 
 new_tmpdir() {
+    # GNU mktemp accepts `mktemp -d`, but some BSD/macOS versions expect a template.
     mktemp -d 2>/dev/null || mktemp -d -t 3dmake_deps
 }
 
@@ -75,6 +75,7 @@ copy_app_from_dmg() {
     hdiutil attach "$dmg_path" -mountpoint "$mount_path" -nobrowse -quiet
     rm -rf "$dest_path"
     local mounted_app
+    # PrusaSlicer's DMG nests the app under "Original Prusa Drivers" instead of the volume root.
     mounted_app="$(find "$mount_path" -maxdepth 3 -name "$app_name" -type d -print -quit)"
     if [[ -z "$mounted_app" ]]; then
         echo "Could not find $app_name in $dmg_path" >&2
@@ -88,23 +89,9 @@ copy_app_from_dmg() {
     hdiutil detach "$mount_path" -quiet
 
     if command -v xattr >/dev/null; then
+        # Downloaded DMGs can add quarantine metadata that makes Gatekeeper warn or block helper apps.
         xattr -dr com.apple.quarantine "$dest_path" 2>/dev/null || true
     fi
-}
-
-archive_macos_app() {
-    local app_name="$1"
-    local app_path="$DEPDIR/macos/$app_name"
-    local archive_path="$DEPDIR/macos/$app_name.tar.xz"
-
-    if [[ ! -d "$app_path" ]]; then
-        echo "Cannot archive missing app bundle: $app_path" >&2
-        exit 1
-    fi
-
-    echo "Creating $archive_path"
-    rm -f "$archive_path"
-    COPYFILE_DISABLE=1 tar -cJf "$archive_path" -C "$DEPDIR/macos" "$app_name"
 }
 
 download_macos() {
@@ -130,9 +117,6 @@ download_macos() {
     curl -L "$PRUSASLICER_MACOS_URL" -o "$tmpdir/prusaslicer.dmg"
 
     copy_app_from_dmg "$tmpdir/prusaslicer.dmg" "PrusaSlicer.app" "$DEPDIR/macos/PrusaSlicer.app" "$tmpdir/prusaslicer_mount"
-
-    archive_macos_app "OpenSCAD.app"
-    archive_macos_app "PrusaSlicer.app"
 
     rm -rf "$tmpdir"
 }

--- a/scripts/macos_build.sh
+++ b/scripts/macos_build.sh
@@ -11,24 +11,7 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
     exit 1
 fi
 
-macos_deps_ready() {
-    [[ -x "deps/macos/OpenSCAD.app/Contents/MacOS/OpenSCAD" && -x "deps/macos/PrusaSlicer.app/Contents/MacOS/PrusaSlicer" ]]
-}
-
-extract_macos_deps() {
-    if [[ -f "deps/macos/OpenSCAD.app.tar.xz" && -f "deps/macos/PrusaSlicer.app.tar.xz" ]]; then
-        echo "Extracting bundled macOS dependencies..."
-        rm -rf deps/macos/OpenSCAD.app deps/macos/PrusaSlicer.app
-        COPYFILE_DISABLE=1 tar -xJf deps/macos/OpenSCAD.app.tar.xz -C deps/macos
-        COPYFILE_DISABLE=1 tar -xJf deps/macos/PrusaSlicer.app.tar.xz -C deps/macos
-    fi
-}
-
-if ! macos_deps_ready; then
-    extract_macos_deps
-fi
-
-if ! macos_deps_ready; then
+if [[ ! -x "deps/macos/OpenSCAD.app/Contents/MacOS/OpenSCAD" || ! -x "deps/macos/PrusaSlicer.app/Contents/MacOS/PrusaSlicer" ]]; then
     echo "Missing bundled macOS dependencies. Run scripts/get_deps.sh macos first."
     exit 1
 fi

--- a/scripts/macos_build.sh
+++ b/scripts/macos_build.sh
@@ -1,0 +1,51 @@
+#! /bin/bash
+set -euo pipefail
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
+    echo "Usage: scripts/macos_build.sh [--release]"
+    exit 0
+fi
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "macOS builds must be created on macOS."
+    exit 1
+fi
+
+macos_deps_ready() {
+    [[ -x "deps/macos/OpenSCAD.app/Contents/MacOS/OpenSCAD" && -x "deps/macos/PrusaSlicer.app/Contents/MacOS/PrusaSlicer" ]]
+}
+
+extract_macos_deps() {
+    if [[ -f "deps/macos/OpenSCAD.app.tar.xz" && -f "deps/macos/PrusaSlicer.app.tar.xz" ]]; then
+        echo "Extracting bundled macOS dependencies..."
+        rm -rf deps/macos/OpenSCAD.app deps/macos/PrusaSlicer.app
+        COPYFILE_DISABLE=1 tar -xJf deps/macos/OpenSCAD.app.tar.xz -C deps/macos
+        COPYFILE_DISABLE=1 tar -xJf deps/macos/PrusaSlicer.app.tar.xz -C deps/macos
+    fi
+}
+
+if ! macos_deps_ready; then
+    extract_macos_deps
+fi
+
+if ! macos_deps_ready; then
+    echo "Missing bundled macOS dependencies. Run scripts/get_deps.sh macos first."
+    exit 1
+fi
+
+pipenv sync --dev
+
+if [[ "${1:-}" == "--release" ]]; then
+    echo "Release build"
+    pipenv run python scripts/release_check.py
+fi
+
+pipenv run pyinstaller --clean -y 3dm.spec
+rm -rf dist/3dmake/_internal/deps/macos
+mkdir -p dist/3dmake/_internal/deps
+mkdir -p dist/3dmake/_internal/deps/macos
+cp -R deps/macos/OpenSCAD.app deps/macos/PrusaSlicer.app dist/3dmake/_internal/deps/macos
+cd dist
+rm -f 3dmake_macos.tar.gz
+tar -czf 3dmake_macos.tar.gz 3dmake
+# IMPORTANT: the software must be inside a 3dmake folder in the archive, or auto-update will fail

--- a/utils/bundle_paths.py
+++ b/utils/bundle_paths.py
@@ -36,26 +36,33 @@ class Dependencies:
 
 def get_deps() -> Dependencies:
     os_type = platform.system()
+    bundled_deps = {
+        'Linux': Dependencies(
+            Path('deps/linux/OpenSCAD.AppImage'),
+            Path('deps/linux/PrusaSlicer.AppImage'),
+        ),
+        'Windows': Dependencies(
+            Path('deps/windows/openscad/openscad.exe'),
+            Path('deps/windows/prusaslicer/prusa-slicer-console.exe'),
+        ),
+        'Darwin': Dependencies(
+            Path('deps/macos/OpenSCAD.app/Contents/MacOS/OpenSCAD'),
+            Path('deps/macos/PrusaSlicer.app/Contents/MacOS/PrusaSlicer'),
+        ),
+    }
+
+    if os_type not in bundled_deps:
+        raise RuntimeError(f"Unsupported operating system: {os_type}")
 
     if openscad_env := os.environ.get('THREEDMAKE_OPENSCAD_PATH'):
         openscad_path = Path(openscad_env)
     else:
-        openscad_path = SCRIPT_DIR.joinpath(
-            {
-                'Linux': 'deps/linux/OpenSCAD.AppImage',
-                'Windows': 'deps/windows/openscad/openscad.exe',
-            }[os_type]
-        )
+        openscad_path = SCRIPT_DIR / bundled_deps[os_type].OPENSCAD
 
     if slicer_env := os.environ.get('THREEDMAKE_SLICER_PATH'):
         slicer_path = Path(slicer_env)
     else:
-        slicer_path = SCRIPT_DIR.joinpath(
-            {
-                'Linux': 'deps/linux/PrusaSlicer.AppImage',
-                'Windows': 'deps/windows/prusaslicer/prusa-slicer-console.exe',
-            }[os_type]
-        )
+        slicer_path = SCRIPT_DIR / bundled_deps[os_type].SLICER
 
     return Dependencies(openscad_path, slicer_path)
 


### PR DESCRIPTION
A much cleaner MacOS build implementation which duplicates the existing setup for windows and linux. I have bundled compressed MacOS deps but the script can also download them. tested on a clean MacOS install. Note that a preemptive MacOS download link was added in the readme, feel free to remove those as you see fit.

- Add deps/macos compressed app archives and .gitignore rules to ignore macOS bundles and .DS_Store.
- Extend scripts/get_deps.sh to download/extract macOS DMGs, copy apps from /Applications when available, and archive .app bundles; make it cross-platform (linux|windows|macos|all).
- Add scripts/macos_build.sh to run PyInstaller on macOS, extract bundled apps if needed, and package the dist archive.
- Update 3dm.spec to include common datas list, avoid bundling the deps dir on Darwin, and fix a hidden import name.
- Update utils/bundle_paths.py to recognize Darwin and point to macOS app executable paths.
- Add macholib to Pipfile (and lockfile) for macOS PyInstaller builds.
- Update README and docs/developer.md to mention macOS release artifacts and build steps.
- Add AGENTS.md (guidance for Codex, replicates existing claude.md) and small e2e_test.py fix to consume POST body when present.

Hopefully this suits the project. I'll work on a UI next.